### PR TITLE
Fix: Changes on the Dockerfile to open the right file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY . /app
 
 RUN pip install -r requirements.txt
 
-CMD ["python", "app.py"]
+CMD ["python", "main.py"]


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change updates the command to run the application by replacing `app.py` with `main.py`.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L8-R8): Changed the command to run the application from `app.py` to `main.py`.